### PR TITLE
Updates for current erlang opentelemetry, add textmappropagator

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -116,16 +116,10 @@ let additions =
   }
 -------------------------------
 -}
-
-
 let upstream =
-      https://github.com/purerl/package-sets/releases/download/erl-0.13.6-20200715/packages.dhall sha256:98227ee8945a3c7ca4a105c1001dd067128e504bdd45cb6bd9c4509563d83fb9
+      https://github.com/purerl/package-sets/releases/download/erl-0.14.4-20211012-1/packages.dhall sha256:04b7cb6aaf4cc7323c2560c7b5c2f5e8459d2951997cf5084748e0f1cdbabd26
 
-let overrides = {
-    erl-lists =
-      upstream.erl-lists // { version = "1d059f0df04f1c83f35a6eae706bd86cda8b015e" }
-}
-
+let overrides = {=}
 
 let additions = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,8 +3,9 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "erl-opentelemetry"
-, dependencies = [ "console", "effect", "erl-lists", "erl-tuples" ]
+, dependencies =
+  [ "effect", "erl-lists", "erl-tuples", "maybe", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
-,backend = "purerl"
+, backend = "purerl"
 }

--- a/src/OpenTelemetry.erl
+++ b/src/OpenTelemetry.erl
@@ -15,6 +15,7 @@
         , getTracer/0
         , 'getTracer\''/1
         , status/2
+        , link/2
         ]).
 
 registerMeter(Name, Version) ->
@@ -113,3 +114,5 @@ camel([H | T]) when $a =< H, H =< $z ->
   [H - 32 | T];
 camel(Other) ->
   Other.
+
+link(SpanCtx, Attributes) -> opentelemetry:link(SpanCtx, Attributes).

--- a/src/OpenTelemetry.purs
+++ b/src/OpenTelemetry.purs
@@ -82,6 +82,8 @@ foreign import data SpanCtx :: Type
 foreign import data Ctx :: Type
 foreign import data Status :: Type
 
+foreign import data Link :: Type
+
 newtype TraceId = TraceId Int
 newtype SpanId = SpanId Int
 
@@ -95,3 +97,5 @@ foreign import getTracer :: Effect Tracer
 foreign import getTracer' :: TracerName -> Effect Tracer
 
 foreign import status :: StatusCode -> String -> Status
+
+foreign import link :: forall a. SpanCtx -> Attributes a -> Link

--- a/src/Tracing/Propagator/TextMap.erl
+++ b/src/Tracing/Propagator/TextMap.erl
@@ -1,0 +1,11 @@
+-module(openTelemetry_tracing_propagator_textMap@foreign).
+
+-export([inject/1,extract/1]).
+
+inject(Carrier) -> fun () ->
+  otel_propagator_text_map:inject(Carrier)
+end.
+
+extract(Carrier) -> fun () ->
+  otel_propagator_text_map:extract(Carrier)
+end.

--- a/src/Tracing/Propagator/TextMap.purs
+++ b/src/Tracing/Propagator/TextMap.purs
@@ -1,0 +1,19 @@
+module OpenTelemetry.Tracing.Propagator.TextMap where
+
+
+import Effect (Effect)
+import Erl.Data.List (List, nil)
+import Erl.Data.Tuple (Tuple2)
+import OpenTelemetry (Ctx)
+
+foreign import data Propagator :: Type
+
+-- | Text map propagator default carrier (a list of tuples of ASCII-ish binary strings)
+newtype DefaultCarrier = DefaultCarrier (List (Tuple2 String String))
+
+defaultCarrier :: DefaultCarrier
+defaultCarrier = DefaultCarrier nil
+
+foreign import inject :: DefaultCarrier -> Effect DefaultCarrier
+
+foreign import extract :: DefaultCarrier -> Effect Ctx

--- a/src/Tracing/Span.erl
+++ b/src/Tracing/Span.erl
@@ -1,7 +1,9 @@
 -module(openTelemetry_tracing_span@foreign).
 
 -export([ traceId/1
+        , hexTraceId/1
         , spanId/1
+        , hexSpanId/1
         , traceState/1
         , isRecording/1
         , setAttribute/3
@@ -10,7 +12,6 @@
         , setStatus/2
         , updateName/2
         , endSpan/1
-        , record_to_list/1
         ]).
 
 record_to_list(Record) ->
@@ -21,8 +22,15 @@ record_to_list(Record) ->
 traceId(SpanCtx) ->
   otel_span:trace_id(SpanCtx).
 
+
+hexTraceId(SpanCtx) ->
+  otel_span:hex_trace_id(SpanCtx).
+
 spanId(SpanCtx) ->
   otel_span:span_id(SpanCtx).
+
+hexSpanId(SpanCtx) ->
+  otel_span:hex_span_id(SpanCtx).
 
 traceState(SpanCtx) ->
   otel_span:trace_state(SpanCtx).

--- a/src/Tracing/Span.purs
+++ b/src/Tracing/Span.purs
@@ -1,11 +1,28 @@
-module OpenTelemetry.Tracing.Span where
+module OpenTelemetry.Tracing.Span
+  ( addEvent
+  , endSpan
+  , hexSpanId
+  , hexTraceId
+  , isRecording
+  , setAttribute
+  , setAttributes
+  , setStatus
+  , spanId
+  , traceId
+  , traceState
+  , updateName
+  )
+  where
 
 import Prelude
+
 import Effect (Effect)
-import OpenTelemetry (SpanCtx, Attributes, Status, SpanName, TraceId, SpanId, TraceState)
+import OpenTelemetry (SpanCtx, SpanId, SpanName, Status, TraceId, TraceState)
 
 foreign import traceId :: SpanCtx -> TraceId
+foreign import hexTraceId :: SpanCtx -> String
 foreign import spanId :: SpanCtx -> SpanId
+foreign import hexSpanId :: SpanCtx -> String
 foreign import traceState :: SpanCtx -> TraceState
 foreign import isRecording :: SpanCtx -> Boolean
 foreign import setAttribute :: forall a. SpanCtx -> String -> a -> Effect Unit

--- a/src/Tracing/Tracer.erl
+++ b/src/Tracing/Tracer.erl
@@ -2,6 +2,7 @@
 
 -export([ startSpan/2
         , startChildSpan/3
+        , startLinkedSpan/3
         , endSpan/0
         , withSpan/3
         , setCurrentSpan/1
@@ -21,6 +22,11 @@ startSpan(Tracer, SpanName) ->
 startChildSpan(Ctx, Tracer, SpanName) ->
   fun() ->
       otel_tracer:start_span(Ctx, Tracer, SpanName, #{})
+  end.
+
+startLinkedSpan(Tracer, SpanName, Links) ->
+  fun() ->
+    otel_tracer:start_span(Tracer, SpanName, #{links => Links})
   end.
 
 endSpan() ->

--- a/src/Tracing/Tracer.purs
+++ b/src/Tracing/Tracer.purs
@@ -1,17 +1,33 @@
-module OpenTelemetry.Tracing.Tracer where
+module OpenTelemetry.Tracing.Tracer
+  ( TracedFun
+  , currentChildSpan
+  , currentSpan
+  , setCurrentChildSpan
+  , setCurrentSpan
+  , setStatus
+  , startChildSpan
+  , startLinkedSpan
+  , startSpan
+  , updateName
+  , withSpan
+  )
+  where
 
 import Prelude
-import OpenTelemetry (Tracer, SpanName, Ctx, SpanCtx, Status, Attributes)
+
+import Data.Maybe (Maybe)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn1)
+import Erl.Data.List (List)
 import Erl.Data.Tuple (Tuple2)
-import Data.Maybe (Maybe)
+import OpenTelemetry (Ctx, Link, SpanCtx, SpanName, Status, Tracer)
 
 type TracedFun a
   = EffectFn1 SpanCtx a
 
 foreign import startSpan :: Tracer -> SpanName -> Effect SpanCtx
-foreign import startChildSpan :: SpanCtx -> Tracer -> SpanName -> Effect (Tuple2 SpanCtx Ctx)
+foreign import startChildSpan :: Ctx -> Tracer -> SpanName -> Effect (Tuple2 SpanCtx Ctx)
+foreign import startLinkedSpan :: Tracer -> SpanName -> List Link -> Effect SpanCtx
 
 foreign import withSpan :: forall a. Tracer -> SpanName -> TracedFun a -> Effect a
 


### PR DESCRIPTION
- link
- startLinkedSpan (Not sure what this should look like - really there are a bunch of optional properties on startSpan and I didn't want to figure out the optional property approach right now)
- span hex ids (I don't think these need newtyping, they're just for display I guess? Not referenced by other funs)
- Text map propagator - this is really minimal API just now. Not sure what carrier related functions should look like, this might either be low level "pass an update function", it looks like typeclasses but that may be too opinionated?